### PR TITLE
fix: typescript compile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tiny-slider",
   "version": "2.8.7",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
-  "main": "dist/tiny-slider.js",
+  "main": "src/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
main in package.json should point to path "src/tiny-slider.js" which actually export a `tns` symbol.